### PR TITLE
补充了麻将辅助的相关功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,13 @@
   ![Demo](./example1.png)
   ![Demo](./example2.png)
 
-### 安装方法
+### 安装方法 - 浏览器
 - 安装油猴脚本 TamperMonkey 
 - 导入 **main.js** 或打开 [此链接](https://greasyfork.org/zh-CN/scripts/378059-majsoul-helper) 安装脚本
+
+### 安装方法 - Majsoul Plus
+- 在resources\app\execute中新建文件夹
+- 将execute.json和main.js文件复制到该文件夹
 
 ### 使用方法
 - 牌效染色默认开启

--- a/execute.json
+++ b/execute.json
@@ -1,0 +1,6 @@
+{
+  "name": "科学麻将助手",
+  "author": "Fr0stbyteR",
+  "description": "帮助有眼疾的科学麻将选手看清场况、理性打牌",
+  "entry": "main.js"
+}

--- a/main.js
+++ b/main.js
@@ -842,7 +842,9 @@
                     };
                 }
                 helper = this;
+                view.DesktopMgr.Inst._setChoosedPai = view.DesktopMgr.Inst.setChoosedPai;
                 view.DesktopMgr.Inst.setChoosedPai = function (e) {
+                    view.DesktopMgr.Inst._setChoosedPai(e);
                     if (e !== null){
                         helper.warningDiscards(e);
                     }
@@ -859,27 +861,64 @@
             for (var i = 1; i <=3; i++){
                 var player = view.DesktopMgr.Inst.players[i];
 				for (const pair of player.container_qipai.pais){
-                    pair.model.meshRender.sharedMaterial.setColor(caps.Cartoon.COLOR, this.waringColor(spai, pair.val));
+                    pair.model.meshRender.sharedMaterial.setColor(caps.Cartoon.COLOR, this.waringColor(spai, pair));
 				}
+                for (const pair of player.container_ming.pais){
+                    pair.model.meshRender.sharedMaterial.setColor(caps.Cartoon.COLOR, this.waringColor(spai, pair));
+                }
                 const lastpai =player.container_qipai.last_pai;
                 if (lastpai !== null){
-                    lastpai.model.meshRender.sharedMaterial.setColor(caps.Cartoon.COLOR, this.waringColor(spai, lastpai.val));
+                    lastpai.model.meshRender.sharedMaterial.setColor(caps.Cartoon.COLOR, this.waringColor(spai, lastpai));
                 }
 			}
-        }
-        waringColor(a, b){
-            if (a.type !== b.type) return new Laya.Vector4(1,1,1,1);
-            var c = Math.abs(a.index-b.index);
-            if (c == 0 ) return  new Laya.Vector4(0.4,0.4,1,1);
-            if (a.type != 3){
-                if (c == 3) return new Laya.Vector4(0.6,0.6,1,1);
-                if (a.index <=7 && a.index >= 3){
-                    if (c == 1) return new Laya.Vector4(0.8,0.8,1,1);
-                } else if (a.index > 7){
-                    if (a.index - b.index == 1) return new Laya.Vector4(0.7,0.7,1,1);
-                } else if (b.index - a.index == 1) return new Laya.Vector4(0.7,0.7,1,1);
+            var self = view.DesktopMgr.Inst.players[0];
+            for (const pair of self.container_qipai.pais){
+                pair.model.meshRender.sharedMaterial.setColor(caps.Cartoon.COLOR, this.waringColorSelf(spai, pair));
             }
-            return  new Laya.Vector4(1,1,1,1);
+            for (const pair of self.container_ming.pais){
+                pair.model.meshRender.sharedMaterial.setColor(caps.Cartoon.COLOR, this.waringColorSelf(spai, pair));
+            }
+            const lastpai =self.container_qipai.last_pai;
+            if (lastpai !== null){
+                lastpai.model.meshRender.sharedMaterial.setColor(caps.Cartoon.COLOR, this.waringColorSelf(spai, lastpai));
+            }
+           //const handIn = view.DesktopMgr.Inst.mainrole.hand;
+           // for (const tile of handIn) {
+           //   tile._SetColor(this.waringColorSelf(spai, tile.val));
+           //}
+        }
+        waringColor(a, bmodel){
+            var b = bmodel.val;
+            var defaultColor = bmodel.ismoqie ? new Laya.Vector4(0.7,0.7,0.7,0.7) : new Laya.Vector4(1,1,1,1);
+            if (a.type !== b.type) return defaultColor;
+            var c = Math.abs(a.index-b.index);
+            if (c == 0 ) return  new Laya.Vector4(0.5,0.5,1,1);
+            if (a.type != 3){
+                if (c == 3) {
+                    if (a.index <= 6 && a.index >= 4) return new Laya.Vector4(1,0.8,0.8,1);
+                    return new Laya.Vector4(1,0.5,0.5,1);
+                }
+                if (a.index <=7 && a.index >= 3){
+                    if (c == 1) return new Laya.Vector4(1,1,0.7,1);
+                } else if (a.index > 7){
+                    if (a.index - b.index == 1) return new Laya.Vector4(1,1,0.2,1);
+                } else if (b.index - a.index == 1) return new Laya.Vector4(1,1,0.2,1);
+            }
+            return  defaultColor;
+        }
+        waringColorSelf(a, bmodel){//自己只考虑壁
+            var b = bmodel.val;
+            var defaultColor = bmodel.ismoqie ? new Laya.Vector4(0.7,0.7,0.7,0.7) : new Laya.Vector4(1,1,1,1);
+            if (a.type !== b.type) return defaultColor;
+            var c = Math.abs(a.index-b.index);
+            if (a.type != 3){
+                if (a.index <=7 && a.index >= 3){
+                    if (c == 1) return new Laya.Vector4(1,1,0.7,1);
+                } else if (a.index > 7){
+                    if (a.index - b.index == 1) return new Laya.Vector4(1,1,0.2,1);
+                } else if (b.index - a.index == 1) return new Laya.Vector4(1,1,0.2,1);
+            }
+            return  defaultColor;
         }
         injectUI () {
             if (typeof uiscript === "undefined" || !uiscript.UI_DesktopInfo || typeof ui === "undefined" || !ui.mj.desktopInfoUI.uiView) return setTimeout(this.injectUI, 1000);
@@ -1029,6 +1068,16 @@
                     }
                 }, 2000)
             }
+            if (action.moqie){
+                var dtile =null;
+                for (var j = 0; j < 4; j++){
+                    if (view.DesktopMgr.Inst.players[j].seat == action.seat) {
+                        dtile = view.DesktopMgr.Inst.players[j].container_qipai.last_pai;
+                    }
+                }
+                dtile.ismoqie = true;
+                dtile.model.meshRender.sharedMaterial.setColor(caps.Cartoon.COLOR, new Laya.Vector4(0.7,0.7,0.7,0.7));
+            }
             if (action.hasOwnProperty("operation")) {
                 const operations = action.operation;
                 if (this.auto) {
@@ -1094,6 +1143,11 @@
 					if (dic[str] === undefined) dic[str] = 1;
 					else dic[str]++;
                 }
+                for (const pair of player.container_ming.pais){
+					const str = pair.val.toString();
+					if (dic[str] === undefined) dic[str] = 1;
+					else dic[str]++;
+				}
 			}
 			for (const opt of options){
 				for (const v of opt.v){

--- a/main.js
+++ b/main.js
@@ -10,7 +10,7 @@
 
 (function () {
     'use strict';
-    
+
     /////////////////////////////////////////////////////////////////////////////////////////////////////
     // TENHOU.NET (C)C-EGG http://tenhou.net/
     /////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -24,7 +24,7 @@
         expand: function (t) {
             return t
                 .replace(/(\d)(\d{0,8})(\d{0,8})(\d{0,8})(\d{0,8})(\d{0,8})(\d{0,8})(\d{8})(m|p|s|z)/g, "$1$9$2$9$3$9$4$9$5$9$6$9$7$9$8$9")
-                .replace(/(\d?)(\d?)(\d?)(\d?)(\d?)(\d?)(\d)(\d)(m|p|s|z)/g, "$1$9$2$9$3$9$4$9$5$9$6$9$7$9$8$9") // 57���A�������
+                .replace(/(\d?)(\d?)(\d?)(\d?)(\d?)(\d?)(\d)(\d)(m|p|s|z)/g, "$1$9$2$9$3$9$4$9$5$9$6$9$7$9$8$9") // 57???A???????
                 .replace(/(m|p|s|z)(m|p|s|z)+/g, "$1")
                 .replace(/^[^\d]/, "");
         },
@@ -841,12 +841,45 @@
                         return m(e);
                     };
                 }
+                helper = this;
+                view.DesktopMgr.Inst.setChoosedPai = function (e) {
+                    if (e !== null){
+                        helper.warningDiscards(e);
+                    }
+                }
+
             } else setTimeout(() => {
                 // console.log("Majsoul Helper waiting...");
                 this.inject();
             }, 1000);
             // uiscript.UI_GameEnd.prototype.show = () => game.Scene_MJ.Inst.GameEnd();
             // uiscript.UI_PiPeiYuYue.Inst.addMatch(2);
+        }
+        warningDiscards(spai){
+            for (var i = 1; i <=3; i++){
+                var player = view.DesktopMgr.Inst.players[i];
+				for (const pair of player.container_qipai.pais){
+                    pair.model.meshRender.sharedMaterial.setColor(caps.Cartoon.COLOR, this.waringColor(spai, pair.val));
+				}
+                const lastpai =player.container_qipai.last_pai;
+                if (lastpai !== null){
+                    lastpai.model.meshRender.sharedMaterial.setColor(caps.Cartoon.COLOR, this.waringColor(spai, lastpai.val));
+                }
+			}
+        }
+        waringColor(a, b){
+            if (a.type !== b.type) return new Laya.Vector4(1,1,1,1);
+            var c = Math.abs(a.index-b.index);
+            if (c == 0 ) return  new Laya.Vector4(0.4,0.4,1,1);
+            if (a.type != 3){
+                if (c == 3) return new Laya.Vector4(0.6,0.6,1,1);
+                if (a.index <=7 && a.index >= 3){
+                    if (c == 1) return new Laya.Vector4(0.8,0.8,1,1);
+                } else if (a.index > 7){
+                    if (a.index - b.index == 1) return new Laya.Vector4(0.7,0.7,1,1);
+                } else if (b.index - a.index == 1) return new Laya.Vector4(0.7,0.7,1,1);
+            }
+            return  new Laya.Vector4(1,1,1,1);
         }
         injectUI () {
             if (typeof uiscript === "undefined" || !uiscript.UI_DesktopInfo || typeof ui === "undefined" || !ui.mj.desktopInfoUI.uiView) return setTimeout(this.injectUI, 1000);
@@ -972,7 +1005,7 @@
                         }]
                     }]
                 }
-    
+
             }
             return true;
         }
@@ -1012,25 +1045,62 @@
                         const optionsIn = this.analyseHand(handTiles);
                         const options = [];
                         optionsIn.forEach(option => option && option.n ? options.push(option) : null);
-                        let discard = handTiles.slice(-2, 2);
-                        let discard2 = discard;
+                        //let discard = handTiles.slice(-2, 2);
+                       // let discard2 = discard;
+
+                        this.handleDiscards(options);
+
                         options.sort((a, b) => b.n - a.n);
                         // console.log(JSON.stringify(options));
-                        if (options[0]) discard = tenhou.MPSZ.fromHai136(options[0].da * 4 + 1);
-                        if (options[1]) discard2 = tenhou.MPSZ.fromHai136(options[1].da * 4 + 1);
-                        this.getFromHand(discard).forEach(tile => {
-                            tile._SetColor(new Laya.Vector4(0.6, 1, 0.6, 1));
-                            setTimeout(() => tile._SetColor(new Laya.Vector4(0.6, 1, 0.6, 1)), 750);
+                        var maxn = options[0].n;
+                        for (var i=0;i<options.length;i++){
+                            if ((options[i].n < maxn * 0.8 && i > 0) || options[i].n == 0) break;
+                            var discard = tenhou.MPSZ.fromHai136(options[i].da * 4 + 1);
+                            const color = 3.7 - 3.5 * options[i].n / maxn;
+                             this.getFromHand(discard).forEach(tile => {
+                            tile._SetColor(new Laya.Vector4(color, 1, color, 1));
+                            setTimeout(() => tile._SetColor(new Laya.Vector4(color, 1, color, 1)), 750);
                         });
-                        this.getFromHand(discard2).forEach(tile => {
-                            tile._SetColor(new Laya.Vector4(0.8, 1, 0.8, 1));
-                            setTimeout(() => tile._SetColor(new Laya.Vector4(0.8, 1, 0.8, 1)), 750);
-                        });
-                        console.log(handTiles + " => " + discard);
-                        if (this.auto) this.discard(discard);
+                        }
+
+                        //if (options[0]) discard = tenhou.MPSZ.fromHai136(options[0].da * 4 + 1);
+                        //if (options[1]) discard2 = tenhou.MPSZ.fromHai136(options[1].da * 4 + 1);
+                        //this.getFromHand(discard).forEach(tile => {
+                        //    tile._SetColor(new Laya.Vector4(0.6, 1, 0.6, 1));
+                        //    setTimeout(() => tile._SetColor(new Laya.Vector4(0.6, 1, 0.6, 1)), 750);
+                        //});
+                        //this.getFromHand(discard2).forEach(tile => {
+                        //    tile._SetColor(new Laya.Vector4(0.8, 1, 0.8, 1));
+                        //    setTimeout(() => tile._SetColor(new Laya.Vector4(0.8, 1, 0.8, 1)), 750);
+                        //});
+                        //console.log(handTiles + " => " + discard);
+                        if (this.auto) this.discard(tenhou.MPSZ.fromHai136(options[0].da * 4 + 1));
                     }
                 }
             }
+        }
+
+        handleDiscards(options){
+            var dic = {};
+            for (const player of view.DesktopMgr.Inst.players){
+				for (const pair of player.container_qipai.pais){
+					const str = pair.val.toString();
+					if (dic[str] === undefined) dic[str] = 1;
+					else dic[str]++;
+				}
+                const lastpai =player.container_qipai.last_pai;
+                if (lastpai !== null) {
+                    const str = lastpai.val.toString();
+					if (dic[str] === undefined) dic[str] = 1;
+					else dic[str]++;
+                }
+			}
+			for (const opt of options){
+				for (const v of opt.v){
+                    const vs = tenhou.MPSZ.fromHai136(v * 4 + 1);
+					if (dic[vs] !== undefined) opt.n -= dic[vs];
+				}
+			}
         }
         analyseHand(tilesIn) {
             const restc = (tiles, c34) => {


### PR DESCRIPTION
1. 将牌河以及副露的牌纳入了进张数量的考虑
2. 取消了2枚的限制，按进张数量进行染色的时候，高于最高进张数的80%均会被染色，并且进张数量越大，颜色越深
3. 选牌时对河牌、副露牌进行染色，包括：
(1) 其他三家，红：筋，蓝：同，黄：壁；颜色越深越有用
(2) 自家，仅显示河牌和副露牌中的壁
4. 摸切的河牌灰色提示（貌似和游戏默认的摸切颜色深度有些差异，懒得调整了）
5. 增加了对Majsoul Plus的支持